### PR TITLE
fix(ui): campaign date fields + search placeholder ellipsis

### DIFF
--- a/src/app/sessions/[id]/components/transcript-section.tsx
+++ b/src/app/sessions/[id]/components/transcript-section.tsx
@@ -135,7 +135,7 @@ export function TranscriptSection({
         />
         <input
           type="text"
-          placeholder="Search transcript\u2026"
+          placeholder={'Search transcript\u2026'}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="font-body"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,8 +14,8 @@ interface Campaign {
   id: string;
   name: string;
   description: string | null;
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface Session {
@@ -213,8 +213,8 @@ export default function Dashboard() {
                       <p className="font-body text-sm text-slate-600 mb-1 line-clamp-2">{campaign.description}</p>
                     )}
                     <div className="flex gap-3 font-body text-xs text-slate-400 whitespace-nowrap">
-                      <span className="inline-flex items-center gap-1"><Calendar size={12} />Created {formatDate(campaign.created_at)}</span>
-                      <span className="inline-flex items-center gap-1"><Clock size={12} />Updated {formatTimeAgo(campaign.updated_at)}</span>
+                      <span className="inline-flex items-center gap-1"><Calendar size={12} />Created {formatDate(campaign.createdAt)}</span>
+                      <span className="inline-flex items-center gap-1"><Clock size={12} />Updated {formatTimeAgo(campaign.updatedAt)}</span>
                     </div>
                   </div>
                   <div className="font-body text-xs text-slate-500 whitespace-nowrap flex-shrink-0">


### PR DESCRIPTION
Two small, display-only correctness fixes.

## 1. Dashboard campaign dates render blank
`src/components/Dashboard.tsx` declares the `Campaign` interface with `created_at` / `updated_at` and renders `formatDate(campaign.created_at)` / `formatTimeAgo(campaign.updated_at)`. But `/api/campaigns` returns `db.getCampaigns()` → raw `prisma.campaign.findMany(...)`, and the Prisma `Campaign` model uses `createdAt @map("created_at")` / `updatedAt @map("updated_at")` — the `@map` only renames the **DB column**, not the JSON field, so the API emits `createdAt` / `updatedAt`. The snake_case access is therefore `undefined`, and the "Created"/"Updated" labels render blank/invalid. (The `Session` interface in the same file already uses camelCase.)

**Fix:** use `createdAt` / `updatedAt`.

## 2. Search placeholder shows literal `\u2026`
`src/app/sessions/[id]/components/transcript-section.tsx` had `placeholder="Search transcript\u2026"`. In a JSX double-quoted attribute, `\u2026` is not a Unicode escape — it renders the literal text `\u2026` instead of `…`.

**Fix:** move it into a JS string expression (`placeholder={'Search transcript\u2026'}`) so the escape is interpreted.

## Testing
Verified locally against this branch (based on `staging`): `tsc --noEmit` clean, `eslint` on changed files clean, `npm run build` succeeds. (Display-only changes; no behavior to unit-test.)

## Notes
Targets `staging`. Contributed from the downstream fork `Domo929/dnd-session-recorder`.