### PR TITLE
fix(uploads): accept codec-qualified audio MIME types

### DIFF
--- a/src/app/api/sessions/create-with-upload/route.ts
+++ b/src/app/api/sessions/create-with-upload/route.ts
@@ -10,23 +10,10 @@ import { isTestAccount } from '@/lib/whitelist';
 import { enqueueProcessSession } from '@/services/pipeline/queue';
 import { saveAudio, buildAudioKey } from '@/services/storage';
 import { probeAudioDurationSeconds } from '@/services/audioProcessing';
+import { isAllowedMime } from '@/lib/uploadValidation';
 import { logger, getUserContext } from '@/lib/logger';
 
 const maxFileSize = parseInt(process.env.MAX_FILE_SIZE || '100000000'); // 100MB default
-
-const allowedMimeTypes = [
-  'audio/mpeg',
-  'audio/mp3',
-  'audio/wav',
-  'audio/ogg',
-  'audio/m4a',
-  'audio/x-m4a',
-  'audio/mp4',
-  'audio/aac',
-  'audio/x-aac',
-  'audio/flac',
-  'audio/webm'
-];
 
 /**
  * POST /api/sessions/create-with-upload
@@ -79,7 +66,7 @@ export async function POST(request: NextRequest) {
     // Handle audio upload if provided
     if (audioFile) {
       // Validate file type
-      if (!allowedMimeTypes.includes(audioFile.type)) {
+      if (!isAllowedMime(audioFile.type)) {
         return NextResponse.json(
           { error: 'Invalid file type. Only audio files are allowed.' },
           { status: 400 }

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -7,23 +7,10 @@ import { requireAuth } from '@/lib/auth-utils';
 import { db } from '@/services/database';
 import { saveAudio, buildAudioKey } from '@/services/storage';
 import { probeAudioDurationSeconds } from '@/services/audioProcessing';
+import { isAllowedMime } from '@/lib/uploadValidation';
 import { logger } from '@/lib/logger';
 
 const maxFileSize = parseInt(process.env.MAX_FILE_SIZE || '100000000'); // 100MB default
-
-const allowedMimeTypes = [
-  'audio/mpeg',
-  'audio/mp3',
-  'audio/wav',
-  'audio/ogg',
-  'audio/m4a',
-  'audio/x-m4a',
-  'audio/mp4',
-  'audio/aac',
-  'audio/x-aac',
-  'audio/flac',
-  'audio/webm'
-];
 
 // POST /api/uploads - Upload audio file and create Upload record
 export async function POST(request: NextRequest) {
@@ -38,7 +25,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No audio file provided' }, { status: 400 });
     }
 
-    if (!allowedMimeTypes.includes(file.type)) {
+    if (!isAllowedMime(file.type)) {
       return NextResponse.json(
         { error: 'Invalid file type. Only audio files are allowed.' },
         { status: 400 }

--- a/src/lib/__tests__/uploadValidation.test.ts
+++ b/src/lib/__tests__/uploadValidation.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedMime } from '@/lib/uploadValidation';
+
+describe('isAllowedMime', () => {
+  it('accepts plain allowed audio types', () => {
+    expect(isAllowedMime('audio/webm')).toBe(true);
+    expect(isAllowedMime('audio/mpeg')).toBe(true);
+    expect(isAllowedMime('audio/mp4')).toBe(true);
+  });
+
+  it('accepts codec-qualified types from MediaRecorder', () => {
+    expect(isAllowedMime('audio/webm;codecs=opus')).toBe(true);
+    expect(isAllowedMime('audio/ogg;codecs=opus')).toBe(true);
+    expect(isAllowedMime('audio/mp4; codecs=mp4a.40.2')).toBe(true);
+  });
+
+  it('normalizes case and surrounding whitespace', () => {
+    expect(isAllowedMime('AUDIO/WEBM')).toBe(true);
+    expect(isAllowedMime('  audio/webm ; codecs=opus')).toBe(true);
+  });
+
+  it('rejects non-audio and unknown types', () => {
+    expect(isAllowedMime('video/webm')).toBe(false);
+    expect(isAllowedMime('application/octet-stream')).toBe(false);
+    expect(isAllowedMime('')).toBe(false);
+  });
+
+  it('rejects types containing control characters', () => {
+    expect(isAllowedMime('audio/webm\nContent-Type: text/html')).toBe(false);
+    expect(isAllowedMime('audio/webm\u0000')).toBe(false);
+  });
+});

--- a/src/lib/uploadValidation.ts
+++ b/src/lib/uploadValidation.ts
@@ -1,0 +1,32 @@
+/** Audio MIME types accepted for upload (shared across every upload route). */
+export const allowedMimeTypes = [
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/wav',
+  'audio/ogg',
+  'audio/m4a',
+  'audio/x-m4a',
+  'audio/mp4',
+  'audio/aac',
+  'audio/x-aac',
+  'audio/flac',
+  'audio/webm',
+];
+
+/**
+ * Whether an uploaded file's reported MIME type is an accepted audio type.
+ *
+ * Browsers' MediaRecorder (and some upload widgets) tag the type with
+ * parameters, e.g. "audio/webm;codecs=opus" or "audio/mp4; codecs=mp4a.40.2".
+ * A naive `allowedMimeTypes.includes(type)` rejects those valid recordings, so
+ * we compare on the base type only (case/whitespace normalized).
+ */
+export function isAllowedMime(mimetype: string): boolean {
+  // Reject control characters (e.g. newlines) so a base-type match can't be
+  // smuggled past via header-injection-style input.
+  if (/[\u0000-\u001f\u007f]/.test(mimetype)) {
+    return false;
+  }
+  const baseType = mimetype.split(';')[0].trim().toLowerCase();
+  return allowedMimeTypes.includes(baseType);
+}


### PR DESCRIPTION
## Problem
Browser `MediaRecorder` reports MIME types **with parameters**, e.g. `audio/webm;codecs=opus` or `audio/mp4; codecs=mp4a.40.2`. Both upload paths validate with an exact-match include:

- `src/app/api/uploads/route.ts:41` — `if (!allowedMimeTypes.includes(file.type))`
- `src/app/api/sessions/create-with-upload/route.ts:82` — `if (!allowedMimeTypes.includes(audioFile.type))`

So an in-browser recording (very common: `audio/webm;codecs=opus`) is rejected with *"Invalid file type. Only audio files are allowed."* even though its base type (`audio/webm`) is allowed. The allow-list is also duplicated verbatim in both routes.

## Fix
- Extract the allow-list into a shared `src/lib/uploadValidation.ts` with `isAllowedMime()`, which:
  - compares on the **base type only** (`split(';')[0]`, trimmed, lower-cased) so codec-qualified types pass;
  - rejects MIME strings containing **control characters** so a base match can't be smuggled past via header-injection-style input.
- Wire both upload routes to `isAllowedMime()` (removing the duplicated inline arrays).
- Add unit tests covering plain types, codec-qualified types, case/whitespace normalization, rejected types, and control-character rejection.

No change to the accepted base types or the file-size limit.

## Testing
Verified locally against this branch (based on `staging`):
- `npx vitest run src/lib/__tests__/uploadValidation.test.ts` — 5/5 pass
- `npx tsc --noEmit` — clean
- `eslint` on changed files — clean
- `npm run build` — succeeds

## Notes
Targets `staging`. Contributed from the downstream fork `Domo929/dnd-session-recorder`.