### PR TITLE
fix(audio): probe duration by decoding when the container reports none

### DIFF
--- a/src/services/__tests__/audioProcessing.test.ts
+++ b/src/services/__tests__/audioProcessing.test.ts
@@ -194,6 +194,31 @@ describe('audioProcessing', () => {
   });
 
   describe('getAudioDuration', () => {
+    // Drives the decode fallback: ffmpeg() emits one `progress` event with the
+    // given timemark (or none when null), then `end`.
+    function mockDecodeWithTimemark(timemark: string | null) {
+      const ffmpegFn = ffmpeg as unknown as ReturnType<typeof vi.fn>;
+      ffmpegFn.mockImplementation(() => {
+        const instance: Record<string, unknown> = {};
+        const ret = () => instance;
+        instance.outputOptions = ret;
+        instance.output = ret;
+        instance.on = (event: string, cb: (arg?: unknown) => void) => {
+          if (event === 'end') instance._endCb = cb;
+          if (event === 'error') instance._errorCb = cb;
+          if (event === 'progress') instance._progressCb = cb;
+          return instance;
+        };
+        instance.run = () => {
+          if (timemark && typeof instance._progressCb === 'function') {
+            (instance._progressCb as (arg: { timemark: string }) => void)({ timemark });
+          }
+          if (typeof instance._endCb === 'function') (instance._endCb as () => void)();
+        };
+        return instance;
+      });
+    }
+
     it('returns duration from ffprobe', async () => {
       const ffprobeMock = ffmpeg.ffprobe as unknown as ReturnType<typeof vi.fn>;
       ffprobeMock.mockImplementation((_path: string, cb: (err: Error | null, metadata: { format: { duration: number } }) => void) => {
@@ -215,11 +240,23 @@ describe('audioProcessing', () => {
       );
     });
 
-    it('rejects when duration is missing', async () => {
+    it('falls back to decoding when the container reports no duration', async () => {
       const ffprobeMock = ffmpeg.ffprobe as unknown as ReturnType<typeof vi.fn>;
       ffprobeMock.mockImplementation((_path: string, cb: (err: Error | null, metadata: { format: { duration?: number } }) => void) => {
         cb(null, { format: {} });
       });
+      mockDecodeWithTimemark('00:00:12.34');
+
+      const duration = await getAudioDuration('/some/recorder.webm');
+      expect(duration).toBeCloseTo(12.34, 2);
+    });
+
+    it('rejects when neither ffprobe nor decoding yield a duration', async () => {
+      const ffprobeMock = ffmpeg.ffprobe as unknown as ReturnType<typeof vi.fn>;
+      ffprobeMock.mockImplementation((_path: string, cb: (err: Error | null, metadata: { format: { duration?: number } }) => void) => {
+        cb(null, { format: {} });
+      });
+      mockDecodeWithTimemark(null);
 
       await expect(getAudioDuration('/some/file.mp3')).rejects.toThrow(
         'Could not determine audio duration'

--- a/src/services/audioProcessing.ts
+++ b/src/services/audioProcessing.ts
@@ -21,8 +21,55 @@ export interface SplitOptions {
   outputDir?: string;
 }
 
+/** Parse an FFmpeg `timemark` ("HH:MM:SS.cs") into seconds. */
+function parseTimemark(timemark: string): number {
+  const match = /^(\d+):(\d{2}):(\d{2})(\.\d+)?$/.exec(timemark.trim());
+  if (!match) {
+    const asNumber = Number(timemark);
+    return Number.isFinite(asNumber) ? asNumber : NaN;
+  }
+  const [, hours, minutes, seconds, fraction] = match;
+  return (
+    Number(hours) * 3600 +
+    Number(minutes) * 60 +
+    Number(seconds) +
+    (fraction ? Number(fraction) : 0)
+  );
+}
+
 /**
- * Get audio file duration in seconds using FFmpeg.
+ * Measure duration by fully decoding the stream to a null sink. Streamed
+ * WebM/Ogg clips from the browser's `MediaRecorder` routinely omit a
+ * container-level duration (it's unknown while the recording is still being
+ * written), so `ffprobe` can't report one. Decoding lets FFmpeg count the
+ * actual decoded time.
+ */
+function measureDurationByDecoding(filePath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let lastTime = 0;
+    ffmpeg(filePath)
+      .outputOptions(['-f', 'null'])
+      .output(process.platform === 'win32' ? 'NUL' : '/dev/null')
+      .on('progress', (progress: { timemark?: string }) => {
+        if (progress?.timemark) {
+          const seconds = parseTimemark(progress.timemark);
+          if (Number.isFinite(seconds) && seconds > lastTime) lastTime = seconds;
+        }
+      })
+      .on('end', () => {
+        if (lastTime > 0) resolve(lastTime);
+        else reject(new Error('Could not determine audio duration'));
+      })
+      .on('error', (err: Error) =>
+        reject(new Error(`Failed to decode audio duration: ${err.message}`)),
+      )
+      .run();
+  });
+}
+
+/**
+ * Get audio file duration in seconds using FFmpeg. Falls back to decoding the
+ * stream when the container reports no duration (e.g. `MediaRecorder` WebM).
  */
 export function getAudioDuration(filePath: string): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -32,13 +79,13 @@ export function getAudioDuration(filePath: string): Promise<number> {
         return;
       }
 
-      const duration = metadata.format.duration;
-      if (!duration) {
-        reject(new Error('Could not determine audio duration'));
+      const duration = metadata.format?.duration;
+      if (duration && Number.isFinite(duration) && duration > 0) {
+        resolve(duration);
         return;
       }
 
-      resolve(duration);
+      measureDurationByDecoding(filePath).then(resolve, reject);
     });
   });
 }


### PR DESCRIPTION
## Problem
`getAudioDuration()` (in `src/services/audioProcessing.ts`) reads only `ffprobe`'s container-level `format.duration` and rejects with *"Could not determine audio duration"* when it's absent. Browser `MediaRecorder` WebM/Ogg recordings routinely **omit** the container duration (it's unknown while the file is still being written), so those uploads fail before they can be chunked/transcribed.

This pairs with the codec-qualified-MIME fix — both are needed to reliably accept in-browser recordings.

## Fix
- When `ffprobe` reports no usable duration, fall back to fully decoding the stream to a null sink (`-f null`) and tracking the final FFmpeg `timemark`.
- Add a `parseTimemark()` helper (`HH:MM:SS.cs` → seconds).
- `getAudioDuration()` still resolves directly from `ffprobe` when a valid duration is present, and still rejects when neither path yields one.

## Testing
Verified locally against this branch (based on `staging`):
- `npx vitest run src/services/__tests__/audioProcessing.test.ts` — **13/13 pass** (added: fallback-success and fallback-failure cases)
- `npx tsc --noEmit` — clean
- `eslint` on changed files — clean
- `npm run build` — succeeds

## Notes
Targets `staging`. Contributed from the downstream fork `Domo929/dnd-session-recorder`.