### PR TITLE
ci(pr-gate): harden PR gate for main (#18)

### DIFF
--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -65,10 +65,13 @@ jobs:
               --volume-size 1 \
               --initial-cluster-size 1
           fi
-          # Attach (idempotent): injects DATABASE_URL into the review app.
-          # Tolerate re-runs where the DB is already attached.
-          if ! flyctl postgres attach "$DB_NAME" --app "$APP_NAME" --yes 2>&1 | tee /tmp/attach.log; then
-            grep -qiE "already attached|already exists" /tmp/attach.log
+          # Attach injects DATABASE_URL into the review app. Idempotent: skip if
+          # the app already has DATABASE_URL (a prior run attached it) — otherwise
+          # re-attach errors ("already contains a secret named DATABASE_URL").
+          if flyctl secrets list --app "$APP_NAME" 2>/dev/null | grep -qw DATABASE_URL; then
+            echo "DATABASE_URL already set on $APP_NAME; skipping attach."
+          else
+            flyctl postgres attach "$DB_NAME" --app "$APP_NAME" --yes
           fi
 
       # The review-app action updates existing machines in place; a machine left

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -10,6 +10,12 @@ env:
   FLY_ORG: personal
   NODE_VERSION: '22'
 
+# pull-requests: write is required for the post-deploy step to comment on the PR
+# (the default token is read-only, which 403s the comment).
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   review_app:
     runs-on: ubuntu-latest
@@ -135,13 +141,18 @@ jobs:
         run: |
           echo "Waiting for review app to be ready..."
           for i in {1..30}; do
-            if curl -f -s ${{ needs.review_app.outputs.url }}/api/health; then
+            # --max-time stops a dead/cold app from hanging the whole job.
+            if curl -fsS --max-time 10 "${{ needs.review_app.outputs.url }}/api/health"; then
               echo "✅ App is ready!"
-              break
+              exit 0
             fi
             echo "⏳ Waiting... (attempt $i/30)"
             sleep 10
           done
+          # Fail fast with a clear signal instead of running tests against a
+          # down app (which surfaces as confusing register/TLS timeouts).
+          echo "::error::Review app never became healthy — check the Fly deploy/boot logs"
+          exit 1
 
       - name: Run post-deploy tests
         run: npm run test:post-deploy

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -41,6 +41,11 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           set -euo pipefail
+          # Per-PR auth secret: review sessions must NEVER be a valid signature
+          # on staging/prod. With JWT sessions, sharing NEXTAUTH_SECRET would let
+          # a token minted in a review app authenticate against another env, so
+          # each review app gets its own random secret (isolated from all others).
+          echo "REVIEW_NEXTAUTH_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
           # Create the review app shell first so the DB can attach DATABASE_URL to it.
           flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>/dev/null || true
           # Create a dedicated throwaway Postgres for this PR if it doesn't exist yet.
@@ -60,6 +65,18 @@ jobs:
             grep -qiE "already attached|already exists" /tmp/attach.log
           fi
 
+      # The review-app action updates existing machines in place; a machine left
+      # crashlooping/stopped by an earlier deploy makes its `secrets import` fail
+      # (HTTP 408). Destroy any existing machines so the action always creates a
+      # fresh one. App-level secrets (incl. DATABASE_URL from attach) are kept.
+      - name: Clear stale machines (force fresh deploy)
+        if: github.event.action != 'closed'
+        run: |
+          machines=$(flyctl machine list --app "$APP_NAME" --json 2>/dev/null || echo '[]')
+          echo "$machines" | jq -r '.[].id' | while read -r id; do
+            [ -n "$id" ] && flyctl machine destroy "$id" --app "$APP_NAME" --force || true
+          done
+
       - name: Deploy PR app to Fly.io
         id: deploy
         if: github.event.action != 'closed'
@@ -67,10 +84,14 @@ jobs:
         with:
           name: ${{ env.APP_NAME }}
           config: fly.review.toml
-          # No external connectors: placeholder OpenAI key; AI is mocked via
-          # MOCK_AI_SERVICES in fly.review.toml. DATABASE_URL comes from attach.
+          # Fully isolated — no shared/external connectors:
+          #   NEXTAUTH_SECRET: unique per PR (cannot authenticate other envs)
+          #   OPENAI_API_KEY:  placeholder; AI is mocked (MOCK_AI_SERVICES)
+          #   DATABASE_URL:    the per-PR throwaway Postgres (from attach)
+          # No AWS/Tigris, Google OAuth, or staging/prod secrets are passed, so
+          # storage falls back to the local in-container UPLOAD_DIR.
           secrets: |
-            NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET_STAGING }}
+            NEXTAUTH_SECRET=${{ env.REVIEW_NEXTAUTH_SECRET }}
             OPENAI_API_KEY=sk-review-placeholder-no-external-calls
           vmsize: shared-cpu-1x
           memory: 1024

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -24,24 +24,69 @@ jobs:
       name: review
       # The script in the `deploy` sets the URL output for each review app.
       url: ${{ steps.deploy.outputs.url }}
-    
+
+    env:
+      APP_NAME: pr-${{ github.event.number }}-dnd-rec
+      DB_NAME: pr-${{ github.event.number }}-dnd-rec-db
+
     steps:
       - name: Get code
         uses: actions/checkout@v6
 
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # Each review app gets its own throwaway Postgres — no shared/external DB.
+      - name: Provision & attach ephemeral Postgres
+        if: github.event.action != 'closed'
+        run: |
+          set -euo pipefail
+          # Create the review app shell first so the DB can attach DATABASE_URL to it.
+          flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>/dev/null || true
+          # Create a dedicated throwaway Postgres for this PR if it doesn't exist yet.
+          if ! flyctl status --app "$DB_NAME" >/dev/null 2>&1; then
+            echo "Creating ephemeral Postgres $DB_NAME..."
+            flyctl postgres create \
+              --name "$DB_NAME" \
+              --org "$FLY_ORG" \
+              --region "$FLY_REGION" \
+              --vm-size shared-cpu-1x \
+              --volume-size 1 \
+              --initial-cluster-size 1
+          fi
+          # Attach (idempotent): injects DATABASE_URL into the review app.
+          # Tolerate re-runs where the DB is already attached.
+          if ! flyctl postgres attach "$DB_NAME" --app "$APP_NAME" --yes 2>&1 | tee /tmp/attach.log; then
+            grep -qiE "already attached|already exists" /tmp/attach.log
+          fi
+
       - name: Deploy PR app to Fly.io
         id: deploy
+        if: github.event.action != 'closed'
         uses: superfly/fly-pr-review-apps@1.2.1
         with:
-          name: pr-${{ github.event.number }}-dnd-rec
+          name: ${{ env.APP_NAME }}
           config: fly.review.toml
+          # No external connectors: placeholder OpenAI key; AI is mocked via
+          # MOCK_AI_SERVICES in fly.review.toml. DATABASE_URL comes from attach.
           secrets: |
             NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET_STAGING }}
-            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-            NEXT_PUBLIC_ENVIRONMENT=review
+            OPENAI_API_KEY=sk-review-placeholder-no-external-calls
           vmsize: shared-cpu-1x
-          memory: 512
+          memory: 1024
           cpu: 1
+
+      # On PR close: tear down the review app, then its throwaway Postgres.
+      - name: Destroy review app on PR close
+        if: github.event.action == 'closed'
+        uses: superfly/fly-pr-review-apps@1.2.1
+        with:
+          name: ${{ env.APP_NAME }}
+          config: fly.review.toml
+
+      - name: Destroy ephemeral Postgres on PR close
+        if: github.event.action == 'closed'
+        run: flyctl apps destroy "$DB_NAME" --yes 2>/dev/null || true
 
   test_review_app:
     runs-on: ubuntu-latest

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-  FLY_REGION: bos
+  FLY_REGION: ord
   FLY_ORG: personal
   NODE_VERSION: '22'
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,8 +3,6 @@ name: Production Deployment
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request CI
 
 on:
   pull_request:
-    branches: [main, staging, develop]
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 env:
@@ -113,11 +113,26 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level moderate
-        continue-on-error: true
 
-      - name: Check for known vulnerabilities
-        run: |
-          npx audit-ci --moderate || echo "::warning::Found vulnerabilities in dependencies"
+  # Secret Scanning — fails the gate on verified secrets in the PR diff
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.deps == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan PR diff for secrets
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --only-verified
 
   # Vitest unit tests (pure logic, fast)
   unit-tests:
@@ -292,7 +307,7 @@ jobs:
   pr-comment:
     name: PR Status Comment
     runs-on: ubuntu-latest
-    needs: [lint-and-type-check, security-audit, unit-tests, build, test]
+    needs: [lint-and-type-check, security-audit, secret-scan, unit-tests, build, test]
     if: always()
     permissions:
       pull-requests: write
@@ -314,6 +329,7 @@ jobs:
 
             const lintStatus = '${{ needs.lint-and-type-check.result }}';
             const securityStatus = '${{ needs.security-audit.result }}';
+            const secretStatus = '${{ needs.secret-scan.result }}';
             const unitStatus = '${{ needs.unit-tests.result }}';
             const buildStatus = '${{ needs.build.result }}';
             const testStatus = '${{ needs.test.result }}';
@@ -333,6 +349,7 @@ jobs:
             |-------|--------|
             | Lint & Type Check | ${statusEmoji(lintStatus)} ${lintStatus} |
             | Security Audit | ${statusEmoji(securityStatus)} ${securityStatus} |
+            | Secret Scan | ${statusEmoji(secretStatus)} ${secretStatus} |
             | Unit Tests (Vitest) | ${statusEmoji(unitStatus)} ${unitStatus} |
             | Build | ${statusEmoji(buildStatus)} ${buildStatus} |
             | Integration Tests | ${statusEmoji(testStatus)} ${testStatus} |
@@ -366,7 +383,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [changes, lint-and-type-check, security-audit, unit-tests, build, test, docs-check]
+    needs: [changes, lint-and-type-check, security-audit, secret-scan, unit-tests, build, test, docs-check]
     if: always()
     steps:
       - name: Check CI Status
@@ -407,7 +424,12 @@ jobs:
           if ([ "${{ needs.changes.outputs.deps }}" == "true" ] || [ "${{ needs.changes.outputs.src }}" == "true" ]) && [ "${{ needs.security-audit.result }}" == "failure" ]; then
             failed_jobs+=("Security Audit")
           fi
-          
+
+          # Check secret scan (if src, tests, or deps changed)
+          if ([ "${{ needs.changes.outputs.src }}" == "true" ] || [ "${{ needs.changes.outputs.tests }}" == "true" ] || [ "${{ needs.changes.outputs.deps }}" == "true" ]) && [ "${{ needs.secret-scan.result }}" == "failure" ]; then
+            failed_jobs+=("Secret Scan")
+          fi
+
           if [ ${#failed_jobs[@]} -gt 0 ]; then
             echo "::error::CI checks failed: ${failed_jobs[*]}"
             exit 1

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -21,6 +21,7 @@ Append an entry whenever an action causes an unexpected failure or the user corr
 - The `dnd_data_staging` Fly volume becomes ORPHANED on the next staging deploy (its `[[mounts]]` was removed 2026-06-11) — `fly volumes destroy` it to stop the charge.
 - Staging's `ALLOW_TEST_CLEANUP` secret must be EXACTLY `'true'` since the 2026-06-11 hardening — if staging test cleanup starts 403ing, check that value first.
 - `fluent-ffmpeg` is deprecated/unmaintained (npm install warns). Only two call sites in `audioProcessing.ts` still use it; migrating them to direct `execFile('ffmpeg', …)` drops the dependency. Queued, not urgent.
+- After PR #25 merges, apply branch protection on `main`: require the `CI Status` check, PR-before-merge, squash-only merge, linear history. Deferred until merge so the required check name exists on `main` first.
 
 ## Tooling gotchas
 
@@ -48,6 +49,18 @@ A prior `cd /tmp` in an earlier Bash call made a background dev server run in /t
 ### `docs/` is gitignored (line 88) but some docs are tracked
 Files added before the ignore rule are tracked; newer ones aren't. `git mv` fails on untracked docs — check `git ls-files docs/` first. New docs need `git add -f`.
 
+### Fly review apps each need their own DB — and `postgres attach` has two traps
+Review apps (`fly.review.toml`) shipped no `DATABASE_URL` (the "shared Postgres" comment was aspirational), so the app crashlooped on `entrypoint exit 1`. `fly-review.yml` now provisions a throwaway `pr-<N>-dnd-rec-db` per PR. Traps: (1) `flyctl postgres attach` injects a `postgres://` URL, NOT `postgresql://` — the entrypoint scheme check must accept both (Prisma accepts both). (2) attach is NOT idempotent: re-running errors `already contains a secret named DATABASE_URL` (doesn't match "already attached") — instead check `flyctl secrets list --app X | grep -qw DATABASE_URL` and skip. Also: `flyctl postgres create` (unmanaged PG) is deprecated toward `fly mpg` and region-picky (failed on `bos`, worked on `ord`) — fine for throwaway review DBs, not for anything durable.
+
+### `superfly/fly-pr-review-apps` updates machines IN PLACE → a wedged machine 408s the deploy
+The action runs `flyctl secrets import` (immediate in-place machine update) BEFORE deploying the new image. A machine left crashlooping/stopped by an earlier deploy makes that update time out (HTTP 408), and the action aborts before building the fixed image — so a bad deploy can't self-heal. Destroy existing machines before the deploy step (`flyctl machine list --json | jq -r '.[].id' | while read id; do flyctl machine destroy "$id" --app X --force; done`); app-level secrets (incl. DATABASE_URL) survive.
+
+### Never share `NEXTAUTH_SECRET` across environments
+Review apps reused `NEXTAUTH_SECRET_STAGING`. With JWT sessions, a token minted in one env is a VALID signature in any env sharing the secret — a review app could authenticate against staging/prod. Generate a unique per-env secret (`openssl rand -hex 32` per PR for review).
+
+### `fly-review.yml` needs `permissions: pull-requests: write`, and the readiness gate must fail
+The default workflow token is read-only, so the github-script PR-comment step 403s ("Resource not accessible by integration"). Separately, the "wait for app ready" loop had no `curl --max-time` and ran tests even when health never passed — a down app hung the job ~22 min until timeout, surfacing as confusing `register`/TLS errors. Cap the curl, exit on health, and `exit 1` if it never comes up.
+
 ## Code & test gotchas
 
 ### TS narrowing doesn't follow Vitest assertions
@@ -70,3 +83,9 @@ Before changing what an npm script does, grep `.github/`, `scripts/`, and `Docke
 
 ### A signal that pattern-matches a known failure may have a different cause
 Jobs stuck `pending` looked like a queue bug but were a drifted podman VM clock (13 min behind) interacting with mixed clock sources. Check `SELECT NOW()` vs app time before debugging queue logic. (The "always use raw SQL NOW() in queue writes" rule now lives in `src/services/CLAUDE.md`.)
+
+### Next.js standalone doesn't bundle deps for out-of-band scripts
+`prisma/seed.ts` run via `npx tsx` in the standalone runner threw `Cannot find module 'bcryptjs'`: standalone only traces deps imported by the BUILT server code, not by side scripts. `@prisma/client` resolved (copied + traced) but `bcryptjs` didn't. Keep seed/boot scripts to `@prisma/client` only and embed precomputed values (e.g. a bcrypt hash) instead of importing crypto libs. Make boot-time seeding non-fatal so a seed hiccup degrades to "app up, empty" rather than crashlooping the machine.
+
+### CodeQL `js/clear-text-logging` flags logging an env-sourced password
+The seed logged the demo password for reviewer convenience; because it was env-overridable (`process.env.DEMO_PASSWORD`), CodeQL (high) flagged it as logging a secret and failed the PR. Don't log password values even in seeds — log a non-sensitive literal hint only.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,11 +54,12 @@ if echo "$DATABASE_URL" | grep -qE "^postgres(ql)?://"; then
   # Off by default; production/staging never set SEED_DATABASE.
   if [ "$SEED_DATABASE" = "true" ]; then
     log "Seeding default data (SEED_DATABASE=true)..."
+    # Non-fatal: a seed failure should leave the review app UP (and debuggable),
+    # not crashloop it. The seed is idempotent, so a later boot can still fill in.
     if npx tsx prisma/seed.ts; then
       log "Database seed: OK"
     else
-      error "Database seed failed"
-      exit 1
+      error "Database seed failed — starting app anyway (review data may be missing)"
     fi
   fi
 else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,8 +20,9 @@ fi
 
 log "DATABASE_URL: configured"
 
-# Parse database type
-if echo "$DATABASE_URL" | grep -q "postgresql://"; then
+# Parse database type — accept both postgresql:// and postgres:// (Fly's
+# `postgres attach` injects the latter; Prisma accepts both).
+if echo "$DATABASE_URL" | grep -qE "^postgres(ql)?://"; then
   DB_TYPE="postgresql"
   log "Database type: PostgreSQL"
 
@@ -48,9 +49,21 @@ if echo "$DATABASE_URL" | grep -q "postgresql://"; then
     error "Database initialization failed"
     exit 1
   fi
+
+  # Seed default data for self-contained environments (review apps).
+  # Off by default; production/staging never set SEED_DATABASE.
+  if [ "$SEED_DATABASE" = "true" ]; then
+    log "Seeding default data (SEED_DATABASE=true)..."
+    if npx tsx prisma/seed.ts; then
+      log "Database seed: OK"
+    else
+      error "Database seed failed"
+      exit 1
+    fi
+  fi
 else
   error "Only PostgreSQL databases are supported in production"
-  error "DATABASE_URL must start with postgresql://"
+  error "DATABASE_URL must start with postgresql:// or postgres://"
   exit 1
 fi
 

--- a/fly.review.toml
+++ b/fly.review.toml
@@ -9,6 +9,10 @@
   PORT = "3000"
   HOSTNAME = "0.0.0.0"
   NEXT_PUBLIC_ENVIRONMENT = "review"
+  # Self-contained review app: seed default demo data on boot and mock all AI
+  # so no external services (OpenAI, object storage) are ever contacted.
+  SEED_DATABASE = "true"
+  MOCK_AI_SERVICES = "true"
 
 [http_service]
   internal_port = 3000
@@ -30,8 +34,9 @@
   cpus = 1
   memory_mb = 512  # Smaller for review apps
 
-# Review apps don't need persistent storage for most testing
-# They will use the shared Postgres database
+# Each review app gets its own ephemeral Fly Postgres (pr-<N>-dnd-rec-db),
+# provisioned and attached by .github/workflows/fly-review.yml and destroyed
+# when the PR closes. DATABASE_URL is injected by `flyctl postgres attach`.
 
 [[services]]
   protocol = "tcp"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "uuid": "^11.1.1",
     "zod": "^3.25.76"
   },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "overrides": {
     "next": {
       "postcss": "^8.5.10"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,7 +12,6 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
@@ -22,8 +21,13 @@ const DEMO_PASSWORD = 'demodemo123';
 const CAMPAIGN_NAME = 'The Sunless Citadel';
 const SESSION_ID = 'seed-session-001';
 
+// Precomputed bcryptjs hash of DEMO_PASSWORD (cost 10). Embedded so the seed
+// has no runtime deps beyond @prisma/client — the Next.js standalone image does
+// not reliably bundle bcryptjs for an out-of-band script like this one.
+const DEMO_PASSWORD_HASH = '$2b$10$124CNloSTEqvK4mBS8ijfuC8jGDSJzmSoqEz2sGU5wHAN4k0bu0JG';
+
 async function main(): Promise<void> {
-  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 10);
+  const passwordHash = DEMO_PASSWORD_HASH;
 
   const user = await prisma.user.upsert({
     where: { email: DEMO_EMAIL },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,15 +16,21 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 // Fixed ids make every run idempotent (upsert by id / natural key).
-const DEMO_EMAIL = 'demo@example.com'; // @example.com is blocked from AI calls
-const DEMO_PASSWORD = 'demodemo123';
 const CAMPAIGN_NAME = 'The Sunless Citadel';
 const SESSION_ID = 'seed-session-001';
 
+// Demo credentials. These grant access to NOTHING but this review app's seeded
+// demo data: the DB is a per-PR throwaway and the review NEXTAUTH_SECRET is
+// unique, so these credentials can never authenticate against staging/prod.
+// All three are env-overridable, so a deployer can inject non-committed values
+// (e.g. as Fly secrets) if even the embedded hash is unwanted.
+const DEMO_EMAIL = process.env.DEMO_EMAIL ?? 'demo@example.com'; // @example.com is blocked from AI calls
+const DEMO_PASSWORD = process.env.DEMO_PASSWORD ?? 'demodemo123';
 // Precomputed bcryptjs hash of DEMO_PASSWORD (cost 10). Embedded so the seed
 // has no runtime deps beyond @prisma/client — the Next.js standalone image does
 // not reliably bundle bcryptjs for an out-of-band script like this one.
-const DEMO_PASSWORD_HASH = '$2b$10$124CNloSTEqvK4mBS8ijfuC8jGDSJzmSoqEz2sGU5wHAN4k0bu0JG';
+const DEMO_PASSWORD_HASH =
+  process.env.DEMO_PASSWORD_HASH ?? '$2b$10$124CNloSTEqvK4mBS8ijfuC8jGDSJzmSoqEz2sGU5wHAN4k0bu0JG';
 
 async function main(): Promise<void> {
   const passwordHash = DEMO_PASSWORD_HASH;
@@ -33,7 +39,6 @@ async function main(): Promise<void> {
     where: { email: DEMO_EMAIL },
     update: {},
     create: {
-      id: 'seed-user-demo',
       email: DEMO_EMAIL,
       name: 'Demo DM',
       password: passwordHash,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env tsx
+/**
+ * Database seed — default data for the review-app basic flows.
+ *
+ * Idempotent: safe to run on every boot. Seeds a demo user with one campaign
+ * and one fully-processed session (transcription + summary + DM TODO) so a
+ * reviewer can exercise sign-in, browse a campaign, and view a completed
+ * session WITHOUT any external services (no OpenAI, no object storage).
+ *
+ * Only runs in the review environment (entrypoint gates on SEED_DATABASE=true).
+ * Demo credentials are intentionally well-known and printed below.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+// Fixed ids make every run idempotent (upsert by id / natural key).
+const DEMO_EMAIL = 'demo@example.com'; // @example.com is blocked from AI calls
+const DEMO_PASSWORD = 'demodemo123';
+const CAMPAIGN_NAME = 'The Sunless Citadel';
+const SESSION_ID = 'seed-session-001';
+
+async function main(): Promise<void> {
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 10);
+
+  const user = await prisma.user.upsert({
+    where: { email: DEMO_EMAIL },
+    update: {},
+    create: {
+      id: 'seed-user-demo',
+      email: DEMO_EMAIL,
+      name: 'Demo DM',
+      password: passwordHash,
+    },
+  });
+
+  const campaign = await prisma.campaign.upsert({
+    where: { userId_name: { userId: user.id, name: CAMPAIGN_NAME } },
+    update: {},
+    create: {
+      name: CAMPAIGN_NAME,
+      description:
+        'A classic dungeon delve into a ruined fortress swallowed by a ravine. Used as review-app demo data.',
+      systemPrompt:
+        'You are summarizing a Dungeons & Dragons session. Focus on plot beats, NPCs, and unresolved threads.',
+      userId: user.id,
+    },
+  });
+
+  await prisma.gamingSession.upsert({
+    where: { id: SESSION_ID },
+    update: {},
+    create: {
+      id: SESSION_ID,
+      userId: user.id,
+      campaignId: campaign.id,
+      title: 'Session 1 — Into the Citadel',
+      sessionDate: new Date('2026-01-15T18:00:00.000Z'),
+      status: 'completed',
+      duration: 7200,
+      transcriptionProgress: 100,
+      totalChunks: 2,
+      chunksCompleted: 2,
+    },
+  });
+
+  // Transcriptions have no natural unique key — replace wholesale for idempotency.
+  await prisma.transcription.deleteMany({ where: { sessionId: SESSION_ID } });
+  await prisma.transcription.createMany({
+    data: [
+      {
+        sessionId: SESSION_ID,
+        startTime: 0,
+        endTime: 42.5,
+        text: 'The party arrives at the lip of the ravine as dusk settles over the Sunless Citadel.',
+        confidence: 0.94,
+      },
+      {
+        sessionId: SESSION_ID,
+        startTime: 42.5,
+        endTime: 95.0,
+        text: 'Talgen the fighter ropes down first, spotting goblin scrawl on the crumbling stone.',
+        confidence: 0.91,
+      },
+      {
+        sessionId: SESSION_ID,
+        startTime: 95.0,
+        endTime: 150.0,
+        text: 'A dragonling cries out from somewhere below, and the cleric calls for caution.',
+        confidence: 0.89,
+      },
+    ],
+  });
+
+  await prisma.summary.upsert({
+    where: { sessionId: SESSION_ID },
+    update: {},
+    create: {
+      sessionId: SESSION_ID,
+      summaryText:
+        'The party descended into the Sunless Citadel at dusk. Talgen scouted ahead and found goblin markings, while a distant dragonling cry hinted at deeper dangers. They resolved to press on carefully.',
+      keyEvents: JSON.stringify([
+        'Arrived at the Sunless Citadel ravine',
+        'Discovered goblin scrawl on the walls',
+        'Heard a dragonling cry from below',
+      ]),
+      charactersInvolved: JSON.stringify(['Talgen (Fighter)', 'The Cleric']),
+    },
+  });
+
+  await prisma.dmTodoList.upsert({
+    where: { sessionId: SESSION_ID },
+    update: {},
+    create: {
+      sessionId: SESSION_ID,
+      content:
+        '## DM TODO\n\n- [ ] Stat the dragonling for next session\n- [ ] Decide what the goblin scrawl reveals\n- [ ] Prep the first combat encounter inside the citadel',
+    },
+  });
+
+  console.log(`[seed] Demo data ready. Sign in with ${DEMO_EMAIL} / ${DEMO_PASSWORD}`);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (err) => {
+    console.error('[seed] ERROR:', err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,13 +22,13 @@ const SESSION_ID = 'seed-session-001';
 // Demo credentials. These grant access to NOTHING but this review app's seeded
 // demo data: the DB is a per-PR throwaway and the review NEXTAUTH_SECRET is
 // unique, so these credentials can never authenticate against staging/prod.
-// All three are env-overridable, so a deployer can inject non-committed values
+// Both are env-overridable, so a deployer can inject non-committed values
 // (e.g. as Fly secrets) if even the embedded hash is unwanted.
 const DEMO_EMAIL = process.env.DEMO_EMAIL ?? 'demo@example.com'; // @example.com is blocked from AI calls
-const DEMO_PASSWORD = process.env.DEMO_PASSWORD ?? 'demodemo123';
-// Precomputed bcryptjs hash of DEMO_PASSWORD (cost 10). Embedded so the seed
-// has no runtime deps beyond @prisma/client — the Next.js standalone image does
-// not reliably bundle bcryptjs for an out-of-band script like this one.
+// Precomputed bcryptjs hash of the default demo password "demodemo123" (cost
+// 10). Embedded so the seed has no runtime deps beyond @prisma/client — the
+// Next.js standalone image does not reliably bundle bcryptjs for an out-of-band
+// script. Override via DEMO_PASSWORD_HASH to use non-committed credentials.
 const DEMO_PASSWORD_HASH =
   process.env.DEMO_PASSWORD_HASH ?? '$2b$10$124CNloSTEqvK4mBS8ijfuC8jGDSJzmSoqEz2sGU5wHAN4k0bu0JG';
 
@@ -129,7 +129,10 @@ async function main(): Promise<void> {
     },
   });
 
-  console.log(`[seed] Demo data ready. Sign in with ${DEMO_EMAIL} / ${DEMO_PASSWORD}`);
+  // Never log a password value (CodeQL js/clear-text-logging): only hint the
+  // well-known default, and only when the embedded default hash is in use.
+  const hint = process.env.DEMO_PASSWORD_HASH ? '' : ' (default password: demodemo123)';
+  console.log(`[seed] Demo data ready. Sign in as ${DEMO_EMAIL}${hint}`);
 }
 
 main()


### PR DESCRIPTION
Implements the PR-gate portion of #18 (part of the #17 pipeline epic).

## Changes to `.github/workflows/pull-request.yml`
- **Scope to main only** — `pull_request` now triggers on `main` (was `main, staging, develop`). Staging/production are reached via promotion, not PRs.
- **Audit is now blocking** — removed `continue-on-error: true` from `npm audit --audit-level moderate`, and removed the redundant `audit-ci` step that only emitted a `::warning::`. A moderate+ advisory now fails the gate.
- **Secret scan added** — new `Secret Scan` job runs trufflehog (`--only-verified`) over the PR diff (`base.sha`..`head.sha`), wired into the aggregate `ci-status` gate and the PR status comment.

## Not in this PR (deliberately)
- **Branch protection on `main`** (require `CI Status`, PR-before-merge, linear history, squash-only) will be applied **after this merges**, so the required check name exists on `main` first.

## Verification
- YAML validates.
- This PR exercises the new gate against itself (secret scan + blocking audit run here).

Closes part of #18.