### PR TITLE
ci(security): unify npm audit + scanners across all CI entry points

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -26,21 +26,25 @@ has been continuously validating — so the contract is "only release when stagi
 ### `pull-request.yml` — PR fast gate
 Triggered on PRs to `main`. Jobs: change detection, **pr-title** (Conventional Commit check on
 the PR title — squash-merge makes it the commit subject on `main`, which feeds git-cliff), lint &
-type check, security audit, secret scan, unit tests (Vitest), build, integration tests (Playwright +
-testcontainers). `ci-status` is the single required check (the `CI Status` context in `protect-main`).
-The pr-title gate is enforced even on docs-only PRs. Skips code jobs for docs-only changes.
+type check, **security audit** (`npm audit --audit-level moderate`, blocking), **secret scan**
+(trufflehog), **CodeQL** (JS/TS static analysis, report-only — not in `ci-status`), unit tests
+(Vitest), build, integration tests (Playwright + testcontainers). `ci-status` is the single required
+check (the `CI Status` context in `protect-main`). The pr-title gate is enforced even on docs-only
+PRs. Skips code jobs for docs-only changes.
 
 ### `staging.yml` — Continuous staging
 Triggered on **push to `main`** (also a nightly `schedule`, and `workflow_dispatch`):
-1. `workflow-tests` — comprehensive Playwright suite (`test:workflows`, testcontainers + mocked AI, 3 browsers)
-2. `deploy-staging` — `flyctl deploy --config fly.staging.toml`, capped health gate (push events only)
-3. `staging-tests` — calls `post-deploy-tests.yml` against deployed staging (`environment: staging`)
+1. `security-audit` — `npm audit --audit-level moderate` (re-checks against advisories disclosed since PR merge); gates `deploy-staging`
+2. `workflow-tests` — comprehensive Playwright suite (`test:workflows`, testcontainers + mocked AI, 3 browsers)
+3. `deploy-staging` — `flyctl deploy --config fly.staging.toml`, capped health gate (push events only)
+4. `staging-tests` — calls `post-deploy-tests.yml` against deployed staging (`environment: staging`)
 
 The nightly schedule runs `workflow-tests` only (no deploy) as a drift check. Docs-only merges skip both.
 
 ### `production.yml` — Manual release & deploy
 **`workflow_dispatch` only**, with a `patch/minor/major` input. One job (`environment: Production`),
-in order: compute next version from the latest `v*` tag → git-cliff release notes → build+Trivy scan →
+in order: **`npm audit --audit-level high`** (blocks the release before build) → compute next version
+from the latest `v*` tag → git-cliff release notes → build+Trivy scan →
 Fly blue-green deploy → `prisma migrate deploy` → health/smoke → **then** create the tag + publish the
 GitHub Release (so a release never exists for something that didn't ship). Single job by design: a tag
 created with `GITHUB_TOKEN` does NOT trigger `on: push: tags`, so tag + deploy must share one run.
@@ -52,7 +56,9 @@ staging default) — one suite serves staging pushes, review apps, and productio
 
 ### `fly-review.yml` — Review App Deployments
 Creates temporary Fly.io review environments per PR (`environment: review`). Lets you test PR changes in an
-isolated deployed environment.
+isolated deployed environment. A `npm audit --audit-level moderate` step gates the deploy — the review app
+is a deployed environment, so it gets the same audit bar as PR/staging (this was the gap that let stale
+packages reach staging).
 
 ### Release notes (`cliff.toml`)
 git-cliff config at the repo root maps Conventional Commit prefixes to public release sections
@@ -61,7 +67,8 @@ are skipped). The public changelog is the GitHub Releases page (repo is public).
 
 ## Gate levels & env contract
 
-- **npm audit:** `pull-request.yml` fails on `--audit-level moderate` (the dependency gate runs at the PR, not on deploy). `production.yml` runs a Trivy image scan (report-only → Security tab). Low-severity findings never block — don't take risky major bumps just to silence lows.
+- **Audit gate contract (consistent across every CI entry point):** `npm audit` runs on **PR, staging, review apps** at `--audit-level moderate` (blocking) and on **production** at `--audit-level high` (blocking). **Low-severity findings never block anywhere** — don't take risky major bumps just to silence lows (see LESSONS.md: `npm audit fix --force` downgrades majors). Rationale for the prod=high split: PR/staging/review catch moderates early and cheaply (no deploy at risk); the manual prod release blocks only on high+ so a freshly-disclosed moderate can't wedge an urgent ship. The audit reads `package-lock.json`, so these steps don't need `npm ci`.
+- **Scanners (consistent set):** `npm audit` everywhere (above); **trufflehog** secret scan on PRs (`--only-verified`, blocking); **CodeQL** JS/TS static analysis on PRs (report-only, surfaces in the Security tab, not in `ci-status`); **Trivy** image scan on the production image build (report-only → SARIF → Security tab, `CRITICAL,HIGH`).
 - **GitHub Environments are case-sensitive.** The deploy jobs reference `Production` (capital) and `staging` (lowercase) to match the existing environments; a casing typo silently spawns a *new* empty environment. `FLY_API_TOKEN` is a repo-level secret, so deploys don't depend on env-scoped secrets.
 - **Staging-suite secrets:** workflows must pass `TEST_CLEANUP_KEY` (GitHub secret) or test-user cleanup silently no-ops, leaving users in the staging DB. The staging Fly app itself needs `TEST_CLEANUP_KEY` + `ALLOW_TEST_CLEANUP=true` (exact string — staging runs `NODE_ENV=production`).
 - `NODE_VERSION: '22'` is set per-workflow env (matches the Dockerfile); watch for stray hardcoded `node-version:` values in individual steps.

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Get code
         uses: actions/checkout@v6
 
+      # Gate the review-app deploy on a dependency audit — vulnerable/stale
+      # packages must not reach a deployed environment (this is the gap that let
+      # stale packages slip into staging). Same level as the PR + staging gate
+      # (moderate). npm audit reads package-lock.json, so no install is needed.
+      - name: Setup Node.js (for audit)
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit dependencies
+        if: github.event.action != 'closed'
+        run: npm audit --audit-level moderate
+
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -43,6 +43,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # --- Dependency audit gate (fail before we build/ship) ---
+      # Prod blocks on HIGH+ only (PR + staging gate at moderate); lows never
+      # block. npm audit reads package-lock.json, so no install is needed.
+      - name: Setup Node.js (for audit)
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit dependencies
+        run: npm audit --audit-level high
+
       # --- Version & release notes (computed before we ship; published after) ---
       - name: Compute next version
         id: version

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -163,6 +163,31 @@ jobs:
           head: ${{ github.event.pull_request.head.sha }}
           extra_args: --only-verified
 
+  # Static analysis — CodeQL for JS/TS. Report-only: findings surface in the
+  # Security tab / as PR code-scanning annotations but do NOT gate the merge
+  # (deliberately absent from ci-status). Lets us watch signal before blocking.
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:javascript-typescript'
+
   # Vitest unit tests (pure logic, fast)
   unit-tests:
     name: Unit Tests (Vitest)

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -51,6 +51,24 @@ jobs:
               - 'tests/**'
               - 'playwright.config.*'
 
+  # Dependency audit — same gate as the PR (moderate). Staging redeploys on every
+  # push to main, so this re-checks against advisories disclosed since the PR
+  # merged. npm audit reads package-lock.json; no install needed.
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit dependencies
+        run: npm audit --audit-level moderate
+
   # Comprehensive workflow tests (testcontainers + mocked AI) — the heavier suite
   # that does NOT run on the PR fast gate.
   workflow-tests:
@@ -109,7 +127,7 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
-    needs: [changes, workflow-tests]
+    needs: [changes, workflow-tests, security-audit]
     if: github.event_name == 'push' && (needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true')
     environment: staging
     steps:


### PR DESCRIPTION
Closes #22 (part of #17 — cross-cutting security).

## Problem
Audit/scanner coverage was uneven across CI. Most notably, `fly-review.yml` had **no dependency audit** — the specific gap that let stale packages reach staging.

## Changes
Every CI entry point now runs `npm audit` at a consistent, documented level:

| Entry point | npm audit | secret scan | static/image scan |
|---|---|---|---|
| PR (`pull-request.yml`) | moderate (blocking) | trufflehog | **CodeQL (report-only, new)** |
| staging (`staging.yml`) | **moderate (new)**, gates deploy | — | — |
| prod (`production.yml`) | **high (new)**, before build | — | Trivy (report-only) |
| review app (`fly-review.yml`) | **moderate (new)**, gates deploy | — | — |

- **`fly-review.yml`** — adds an audit step gating the review-app deploy (`if: action != 'closed'` so teardown isn't blocked).
- **`staging.yml`** — adds a `security-audit` job, added to `deploy-staging`'s `needs`. Also runs on the nightly schedule as a drift check.
- **`production.yml`** — adds `npm audit --audit-level high` before the image build.
- **`pull-request.yml`** — adds a report-only CodeQL JS/TS job (deliberately **not** in `ci-status`, so it doesn't block merges yet).
- **`.github/CLAUDE.md`** — documents the unified gate contract: PR/staging/review = moderate, prod = high, **lows never block**; plus the consistent scanner set.

## Gate contract (documented)
PR + staging + review fail at **moderate**; prod blocks only at **high** so a freshly-disclosed moderate can't wedge an urgent release. Lows never block anywhere (no risky major bumps to silence lows). `npm audit` reads `package-lock.json`, so the new steps don't need `npm ci`.

## Verification
- All four workflows parse as valid YAML.
- `npm audit` is clean at both `moderate` and `high` on the current tree (`found 0 vulnerabilities`) — gates won't immediately red-fail.

## Notes
- CodeQL upload works because the repo is public (free code scanning). Report-only for now; promote into `ci-status` later if blocking is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)