### PR TITLE
ci: remove no-op bundle-analysis job from PR gate

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -312,7 +312,6 @@ jobs:
             echo "⚠️ No test report generated" >> $GITHUB_STEP_SUMMARY
           fi
 
-  # Bundle Size Check
   # Fast docs-only check
   docs-check:
     name: Documentation Check
@@ -324,38 +323,6 @@ jobs:
         run: |
           echo "✅ Only documentation files changed - skipping code tests"
           echo "This PR contains documentation-only changes and doesn't require comprehensive testing."
-
-  bundle-analysis:
-    name: Bundle Size Analysis
-    runs-on: ubuntu-latest
-    needs: [changes, build]
-    if: needs.changes.outputs.src == 'true'
-    continue-on-error: true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Analyze bundle size
-        run: |
-          if command -v npx &> /dev/null && npx --help | grep -q "@next/bundle-analyzer"; then
-            ANALYZE=true npm run build
-          else
-            echo "Bundle analyzer not configured, skipping..."
-          fi
-        env:
-          NEXTAUTH_SECRET: test-secret
-          NEXTAUTH_URL: http://localhost:3000
-          # DATABASE_URL: will be set by testcontainers
-        continue-on-error: true
 
   # PR Comment with Status
   pr-comment:


### PR DESCRIPTION
Closes #23 (part of #17 — cleanup + docs).

## What this does
Removes the `bundle-analysis` job from `pull-request.yml`. It presented as a "Bundle Size Analysis" check but was a no-op: it guarded on `@next/bundle-analyzer`, which is **not a dependency and not wired into `next.config`**, so it always fell through to `echo "Bundle analyzer not configured, skipping..."` after paying for `npm ci`. It wasn't referenced by `ci-status` or `pr-comment`, so removing it changes no gating. Also drops a stray `# Bundle Size Check` comment that sat above `docs-check`.

## Why most of #23 is already done
The issue's other cleanup items were resolved by earlier work:
- `post-merge.yml` + its `performance-tests` stub → deleted in the trunk-based refactor (#26)
- `staging.yml` `redis` service block / "SQLite for testing" comment → already gone (file rewritten)
- `.github/CLAUDE.md` → already describes the actual trunk-based flow; no stale refs (verified)

So the only remaining stub masquerading as a real check was `bundle-analysis`.

## Deliberately out of scope
The `Check formatting (if configured)` prettier step in `lint-and-type-check` is also currently a no-op (prettier is installed but there's no config file for its guard to match). Unlike `bundle-analysis` it's a `continue-on-error` step, not a named check showing false green, so it's left as-is and tracked in #29.

## Verification
- `pull-request.yml` parses as valid YAML.
- No lingering `bundle` references in the workflow; `ci-status` / `pr-comment` `needs` lists were already free of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)