### PR TITLE
feat(billing): add Stripe subscription billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ See `.env.example` for all variables. Critical ones:
 - `UPLOAD_DIR` - Audio file storage path (local fallback, default: `./uploads`)
 - `BUCKET_NAME` / `AWS_ENDPOINT_URL_S3` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` - Tigris object storage for audio (set by `fly storage create`); local disk used when unset
 - `STAGING_WHITELIST` - Comma-separated emails for staging access control
+- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` - Stripe billing (use a restricted `rk_` key; billing endpoints 503 when unset)
+- `STRIPE_PRICE_ID` - Optional pinned subscription price (else found/created by product metadata; see `scripts/stripe-setup.ts`)
 
 ## Authentication
 
@@ -119,6 +121,7 @@ if (!session?.user?.id) {
 These endpoints explicitly skip authentication:
 - `/api/auth/*` - NextAuth session management (signin, signup, etc.)
 - `/api/health` - Health check for monitoring
+- `/api/billing/webhook` - Stripe webhook; authenticated by signature verification (`STRIPE_WEBHOOK_SECRET`), not by session
 - Any future public APIs must be documented here and excluded in middleware
 
 ### Resource Ownership Pattern

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -29,6 +29,9 @@ Append an entry whenever an action causes an unexpected failure or the user corr
 ### `npm audit fix --force` will DOWNGRADE majors to chase audit metadata
 It has twice proposed next 15 → **9.3.3** and next-auth 4 → 3 (the first run ballooned 28 vulns to 100). Never use `--force`; plain `npm audit fix` only applies semver-compatible bumps. Most transitive advisories here are fixed with `package.json` `"overrides"`, not upgrades.
 
+### `prisma migrate dev` cannot run non-interactively — not even with a fake TTY
+It hard-fails in non-interactive shells, and `script -q /dev/null` gets past that only to hit the y/N confirmation, which ignores piped stdin (answers "no"). Working path: generate the SQL with `prisma migrate diff --from-url $DATABASE_URL --to-schema-datamodel prisma/schema.prisma --script`, save it as a hand-written migration (guards + default constraint names per `prisma/CLAUDE.md`), apply with `migrate deploy`, verify with `migrate diff --exit-code`.
+
 ### Doubly-nested npm overrides FLAP — keep overrides at most one level deep
 `"next-auth": {"@auth/core": {"cookie": …}}` applied at lockfile-regen time, then a later plain `npm install` silently re-resolved the deep entry back to the vulnerable version. Use a global or one-level override instead. If an override-protected vuln "comes back", suspect this before suspecting new advisories.
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -94,5 +94,8 @@ Jobs stuck `pending` looked like a queue bug but were a drifted podman VM clock 
 ### Next.js standalone doesn't bundle deps for out-of-band scripts
 `prisma/seed.ts` run via `npx tsx` in the standalone runner threw `Cannot find module 'bcryptjs'`: standalone only traces deps imported by the BUILT server code, not by side scripts. `@prisma/client` resolved (copied + traced) but `bcryptjs` didn't. Keep seed/boot scripts to `@prisma/client` only and embed precomputed values (e.g. a bcrypt hash) instead of importing crypto libs. Make boot-time seeding non-fatal so a seed hiccup degrades to "app up, empty" rather than crashlooping the machine.
 
+### CodeQL "default setup" and the advanced workflow are mutually exclusive
+Enabling CodeQL **default setup** (repo Settings → Code security → Code scanning) while the repo also runs the **advanced** `github/codeql-action/analyze` workflow (ours lives in `pull-request.yml`, documented in `.github/CLAUDE.md`) makes the advanced job's SARIF upload fail: `CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`. The analysis itself succeeds — only the upload 422s. Fix: disable default setup (`gh api -X PATCH repos/<owner>/<repo>/code-scanning/default-setup -f state=not-configured`), then re-run the failed job (`gh run rerun <id> --failed`). The repo's design is the advanced workflow; don't toggle on default setup.
+
 ### CodeQL `js/clear-text-logging` flags logging an env-sourced password
 The seed logged the demo password for reviewer convenience; because it was env-overridable (`process.env.DEMO_PASSWORD`), CodeQL (high) flagged it as logging a secret and failed the PR. Don't log password values even in seeds — log a non-sensitive literal hint only.

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,13 @@ export default withAuth(
           return true;
         }
 
+        // Allow the Stripe webhook — requests come from Stripe's servers
+        // (no session cookie) and are authenticated by signature
+        // verification against STRIPE_WEBHOOK_SECRET inside the route
+        if (req.nextUrl.pathname === '/api/billing/webhook') {
+          return true;
+        }
+
         // Allow the test cleanup endpoint — it enforces its own auth
         // (X-Test-Key must match TEST_CLEANUP_KEY, 503s when unconfigured)
         // and test teardown contexts have no session cookie

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.71.1",
+        "stripe": "^22.2.0",
         "tailwind-merge": "^3.3.1",
         "uuid": "^11.1.1",
         "zod": "^3.25.76"
@@ -10611,6 +10612,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.71.1",
+    "stripe": "^22.2.0",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.1.1",
     "zod": "^3.25.76"

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -21,6 +21,7 @@ Defines the data model for PostgreSQL. Uses `cuid()` for primary keys on most mo
 | `Summary` | AI-generated session summary | summaryText, keyEvents, isEdited, originalText |
 | `DmTodoList` | AI-generated DM notes | content (markdown), isEdited, originalText |
 | `Upload` | Audio file metadata | filename, storageKey, size, mimetype, duration |
+| `Subscription` | Mirror of the user's Stripe subscription (webhook-maintained; Stripe is source of truth) | stripeSubscriptionId (unique), status, currentPeriodEnd, cancelAtPeriodEnd |
 | `PipelineJob` | Durable work queue for processing pipeline | status, currentStep, attempts, runAfter (backoff), lockedBy/heartbeatAt (lease) |
 | `TranscriptChunk` | Per-chunk Whisper checkpoint (deleted after stitch) | chunkIndex, totalChunks, status, text |
 

--- a/prisma/migrations/20260612000000_add_stripe_billing/migration.sql
+++ b/prisma/migrations/20260612000000_add_stripe_billing/migration.sql
@@ -1,0 +1,40 @@
+-- Stripe billing: customer id on User + subscriptions mirror table.
+-- Guarded so partial/manual recovery states don't wedge the migration.
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "stripe_customer_id" TEXT;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "subscriptions" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "stripe_subscription_id" TEXT NOT NULL,
+    "stripe_customer_id" TEXT NOT NULL,
+    "stripe_price_id" TEXT,
+    "status" TEXT NOT NULL,
+    "current_period_end" TIMESTAMP(3),
+    "cancel_at_period_end" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "subscriptions_stripe_subscription_id_key" ON "subscriptions"("stripe_subscription_id");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "subscriptions_user_id_idx" ON "subscriptions"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "User_stripe_customer_id_key" ON "User"("stripe_customer_id");
+
+-- AddForeignKey (no IF NOT EXISTS for constraints; guard via catalog check)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'subscriptions_user_id_fkey'
+  ) THEN
+    ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,20 +8,22 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String?   @unique
-  emailVerified DateTime?
-  image         String?
-  password      String?   // Keep for local auth
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  id               String    @id @default(cuid())
+  name             String?
+  email            String?   @unique
+  emailVerified    DateTime?
+  image            String?
+  password         String?   // Keep for local auth
+  stripeCustomerId String?   @unique @map("stripe_customer_id")
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   accounts       Account[]
   sessions       Session[] // NextAuth authentication sessions (login tokens)
   campaigns      Campaign[]
   uploads        Upload[]
   gamingSessions GamingSession[] // D&D game sessions
+  subscriptions  Subscription[]
 }
 
 model Account {
@@ -208,6 +210,27 @@ model DmTodoList {
   session     GamingSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
 
   @@map("dm_todo_lists")
+}
+
+// Mirror of the user's Stripe subscription, kept current by the Stripe
+// webhook (/api/billing/webhook). Stripe is the source of truth; rows are
+// upserted by stripeSubscriptionId so webhook replays stay idempotent.
+model Subscription {
+  id                   String    @id @default(cuid())
+  userId               String    @map("user_id")
+  stripeSubscriptionId String    @unique @map("stripe_subscription_id")
+  stripeCustomerId     String    @map("stripe_customer_id")
+  stripePriceId        String?   @map("stripe_price_id")
+  status               String    // Stripe subscription status: active, trialing, past_due, canceled, incomplete, ...
+  currentPeriodEnd     DateTime? @map("current_period_end")
+  cancelAtPeriodEnd    Boolean   @default(false) @map("cancel_at_period_end")
+  createdAt            DateTime  @default(now()) @map("created_at")
+  updatedAt            DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("subscriptions")
 }
 
 model Upload {

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env tsx
+/**
+ * One-time Stripe setup: creates the "Basic subscription" product ($10/month,
+ * digital-goods tax code for Managed Payments) in the account that
+ * STRIPE_SECRET_KEY points at, or finds the one this app already created.
+ * Prints the price id to pin as STRIPE_PRICE_ID.
+ *
+ * Idempotent: products are tagged with metadata `app=dnd-session-recorder`
+ * and reused on re-runs. (The app also lazy-creates this on first checkout —
+ * the script just lets you pin STRIPE_PRICE_ID explicitly per environment.)
+ *
+ * Usage:
+ *   set -a && source .env && set +a   # or export STRIPE_SECRET_KEY=rk_...
+ *   npx tsx scripts/stripe-setup.ts
+ */
+
+import Stripe from 'stripe';
+import { exit } from 'process';
+
+// Keep in sync with src/services/billing.ts
+const PRODUCT_METADATA_KEY = 'app';
+const PRODUCT_METADATA_VALUE = 'dnd-session-recorder';
+const STRIPE_PREVIEW_API_VERSION = '2026-02-25.preview';
+
+async function main() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    console.error('STRIPE_SECRET_KEY is not set.');
+    console.error('Get a restricted key (rk_...) from the Stripe Dashboard → Developers → API keys,');
+    console.error('add it to .env, then run: set -a && source .env && set +a && npx tsx scripts/stripe-setup.ts');
+    exit(1);
+  }
+
+  const stripe = new Stripe(key);
+
+  const products = await stripe.products.list({ active: true, limit: 100 });
+  const existing = products.data.find(
+    (p) => p.metadata[PRODUCT_METADATA_KEY] === PRODUCT_METADATA_VALUE && p.default_price
+  );
+  if (existing) {
+    const priceId =
+      typeof existing.default_price === 'string'
+        ? existing.default_price
+        : (existing.default_price as Stripe.Price).id;
+    console.log(`Found existing product: ${existing.id} (${existing.name})`);
+    console.log(`\nAdd to your environment:\nSTRIPE_PRICE_ID="${priceId}"`);
+    return;
+  }
+
+  const product = await stripe.products.create(
+    {
+      name: 'Basic subscription',
+      description: 'A basic subscription to our service',
+      tax_code: 'txcd_10103100',
+      default_price_data: {
+        unit_amount: 1000,
+        currency: 'usd',
+        recurring: { interval: 'month' },
+      },
+      metadata: { [PRODUCT_METADATA_KEY]: PRODUCT_METADATA_VALUE },
+    },
+    { apiVersion: STRIPE_PREVIEW_API_VERSION }
+  );
+
+  console.log(`Created product: ${product.id} (${product.name})`);
+  console.log(`\nAdd to your environment:\nSTRIPE_PRICE_ID="${product.default_price}"`);
+}
+
+main().catch((err) => {
+  console.error('Stripe setup failed:', err.message);
+  exit(1);
+});

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -36,6 +36,7 @@ Next.js App Router uses file-system routing:
 | `/campaigns` | `campaigns/page.tsx` | Campaign list with CRUD |
 | `/campaigns/[id]` | `campaigns/[id]/page.tsx` | Campaign detail with session timeline |
 | `/uploads` | `uploads/page.tsx` | Upload management |
+| `/billing` | `billing/page.tsx` | Subscription status + Stripe Checkout entry (success/cancel return URL) |
 | `/settings` | `settings/page.tsx` | User settings |
 | `/about` | `about/page.tsx` | About page |
 

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -55,6 +55,11 @@ Non-ownership is masked as **404** (never 403) so resource existence doesn't lea
 ### User (`user/`)
 - `accounts/route.ts` - `GET` linked OAuth accounts
 
+### Billing (`billing/`)
+- `checkout/route.ts` - `POST` create a Stripe Checkout Session (subscription mode, Managed Payments); returns `{ url }` to redirect to. Sensitive-action rate limited.
+- `subscription/route.ts` - `GET` the user's subscription status from the `subscriptions` mirror table
+- `webhook/route.ts` - `POST` Stripe webhook (PUBLIC in middleware — authenticated by signature verification against `STRIPE_WEBHOOK_SECRET`, never by session). Handles `checkout.session.completed` + `customer.subscription.updated/deleted`; returns 500 on handler failure so Stripe retries (handlers are idempotent upserts). All Stripe logic lives in `src/services/billing.ts`. Endpoints 503 when `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` are unset.
+
 ### Utility
 - `health/route.ts` - `GET` health check (public, no auth). Never echo raw DB/driver error messages in its response — log them instead.
 - `test/cleanup-user/route.ts` - `DELETE` test cleanup utility. Fails closed: in production-mode envs it requires `ALLOW_TEST_CLEANUP` to be EXACTLY `'true'` (staging runs `NODE_ENV=production`, so staging must set it; production never should). Key compared with `crypto.timingSafeEqual`.

--- a/src/app/api/billing/__tests__/webhook.test.ts
+++ b/src/app/api/billing/__tests__/webhook.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Stripe from 'stripe';
+
+vi.mock('@/services/billing', () => ({
+  handleStripeEvent: vi.fn(),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { POST } from '../webhook/route';
+import { handleStripeEvent } from '@/services/billing';
+
+const WEBHOOK_SECRET = 'whsec_test_secret';
+
+// Only used offline: signature generation and verification, no API calls
+const stripe = new Stripe('sk_test_dummy');
+
+function checkoutCompletedPayload(): string {
+  return JSON.stringify({
+    id: 'evt_test_1',
+    object: 'event',
+    type: 'checkout.session.completed',
+    data: {
+      object: {
+        id: 'cs_test_1',
+        object: 'checkout.session',
+        mode: 'subscription',
+        subscription: 'sub_test_1',
+        client_reference_id: 'user_1',
+      },
+    },
+  });
+}
+
+function webhookRequest(payload: string, signature?: string): Request {
+  return new Request('http://localhost/api/billing/webhook', {
+    method: 'POST',
+    body: payload,
+    headers: signature ? { 'stripe-signature': signature } : {},
+  });
+}
+
+function signedHeader(payload: string, secret = WEBHOOK_SECRET): string {
+  return stripe.webhooks.generateTestHeaderString({ payload, secret });
+}
+
+describe('POST /api/billing/webhook', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+    process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns 503 when the webhook secret is not configured', async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    const res = await POST(webhookRequest(checkoutCompletedPayload()));
+    expect(res.status).toBe(503);
+    expect(handleStripeEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the signature header is missing', async () => {
+    const res = await POST(webhookRequest(checkoutCompletedPayload()));
+    expect(res.status).toBe(400);
+    expect(handleStripeEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the signature does not match the payload', async () => {
+    const payload = checkoutCompletedPayload();
+    const res = await POST(webhookRequest(payload, signedHeader(payload, 'whsec_wrong_secret')));
+    expect(res.status).toBe(400);
+    expect(handleStripeEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the payload was tampered with after signing', async () => {
+    const signature = signedHeader(checkoutCompletedPayload());
+    const tampered = checkoutCompletedPayload().replace('user_1', 'attacker');
+    const res = await POST(webhookRequest(tampered, signature));
+    expect(res.status).toBe(400);
+    expect(handleStripeEvent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a correctly signed event and returns 200', async () => {
+    const payload = checkoutCompletedPayload();
+    const res = await POST(webhookRequest(payload, signedHeader(payload)));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    expect(handleStripeEvent).toHaveBeenCalledTimes(1);
+    const event = vi.mocked(handleStripeEvent).mock.calls[0][0];
+    expect(event.type).toBe('checkout.session.completed');
+  });
+
+  it('returns 500 (so Stripe retries) when event handling fails', async () => {
+    vi.mocked(handleStripeEvent).mockRejectedValueOnce(new Error('db down'));
+    const payload = checkoutCompletedPayload();
+    const res = await POST(webhookRequest(payload, signedHeader(payload)));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { requireAuthForSensitiveAction } from '@/lib/auth-utils';
+import { isStripeConfigured } from '@/lib/stripe';
+import { createSubscriptionCheckoutSession } from '@/services/billing';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/billing/checkout
+ * Creates a subscription Checkout Session for the authenticated user and
+ * returns { url } for the browser to redirect to.
+ */
+export async function POST(request: Request) {
+  const { error, user } = await requireAuthForSensitiveAction(request);
+  if (error) return error;
+
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: 'Billing is not configured' }, { status: 503 });
+  }
+
+  try {
+    const baseUrl = process.env.NEXTAUTH_URL || new URL(request.url).origin;
+    const session = await createSubscriptionCheckoutSession(user.id, baseUrl);
+    if (!session.url) {
+      throw new Error('Checkout session has no redirect URL');
+    }
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    logger.error('Failed to create checkout session', err as Error, { userId: user.id });
+    return NextResponse.json({ error: 'Failed to start checkout' }, { status: 500 });
+  }
+}

--- a/src/app/api/billing/subscription/route.ts
+++ b/src/app/api/billing/subscription/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth-utils';
+import { getUserSubscription, isSubscriptionActive } from '@/services/billing';
+
+/**
+ * GET /api/billing/subscription
+ * Returns the authenticated user's subscription status (from our mirror
+ * table, kept current by the Stripe webhook).
+ */
+export async function GET() {
+  const { error, user } = await requireAuth();
+  if (error) return error;
+
+  const subscription = await getUserSubscription(user.id);
+  return NextResponse.json({
+    active: isSubscriptionActive(subscription),
+    subscription: subscription
+      ? {
+          status: subscription.status,
+          currentPeriodEnd: subscription.currentPeriodEnd,
+          cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+        }
+      : null,
+  });
+}

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import type Stripe from 'stripe';
+import { getStripe, isStripeConfigured } from '@/lib/stripe';
+import { handleStripeEvent } from '@/services/billing';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/billing/webhook
+ *
+ * Stripe webhook receiver. PUBLIC in middleware — authentication is the
+ * signature check against STRIPE_WEBHOOK_SECRET (requests are from Stripe's
+ * servers, which carry no user session). Never process an event that fails
+ * verification.
+ *
+ * Handled events: checkout.session.completed,
+ * customer.subscription.updated, customer.subscription.deleted.
+ */
+export async function POST(request: Request) {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret || !isStripeConfigured()) {
+    return NextResponse.json({ error: 'Webhook is not configured' }, { status: 503 });
+  }
+
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+  }
+
+  // Signature is computed over the raw body — read it as text, never JSON
+  const payload = await request.text();
+
+  let event: Stripe.Event;
+  try {
+    event = await getStripe().webhooks.constructEventAsync(payload, signature, webhookSecret);
+  } catch (err) {
+    logger.warn(`Stripe webhook signature verification failed: ${(err as Error).message}`);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  try {
+    await handleStripeEvent(event);
+  } catch (err) {
+    logger.error(`Failed to handle Stripe event ${event.type}`, err as Error);
+    // Non-2xx makes Stripe retry with backoff; handlers are idempotent
+    return NextResponse.json({ error: 'Event handling failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle, CreditCard, XCircle } from 'lucide-react';
+import Button from '@/components/ui/Button';
+import { formatDate } from '@/lib/formatting';
+
+interface SubscriptionResponse {
+  active: boolean;
+  subscription: {
+    status: string;
+    currentPeriodEnd: string | null;
+    cancelAtPeriodEnd: boolean;
+  } | null;
+}
+
+function BillingContent() {
+  const { status } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+
+  const checkoutResult = searchParams.get('checkout'); // 'success' | 'cancelled' | null
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin');
+    }
+  }, [status, router]);
+
+  const { data, isLoading } = useQuery<SubscriptionResponse>({
+    queryKey: ['billing', 'subscription'],
+    queryFn: async () => {
+      const res = await fetch('/api/billing/subscription');
+      if (!res.ok) throw new Error('Failed to load subscription');
+      return res.json();
+    },
+    enabled: status === 'authenticated',
+    // The webhook may land a moment after the success redirect — poll briefly
+    // until the subscription shows up
+    refetchInterval: (query) =>
+      checkoutResult === 'success' && !query.state.data?.active ? 2000 : false,
+  });
+
+  // Once the webhook lands, drop the stale polling trigger from the URL
+  useEffect(() => {
+    if (checkoutResult === 'success' && data?.active) {
+      queryClient.invalidateQueries({ queryKey: ['billing'] });
+    }
+  }, [checkoutResult, data?.active, queryClient]);
+
+  const checkoutMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/billing/checkout', { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || 'Failed to start checkout');
+      return body as { url: string };
+    },
+    onSuccess: ({ url }) => {
+      window.location.assign(url);
+    },
+    onError: (err: Error) => setCheckoutError(err.message),
+  });
+
+  if (status === 'loading' || status === 'unauthenticated') {
+    return null;
+  }
+
+  const subscription = data?.subscription;
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 px-4">
+      <h1 className="text-3xl font-bold font-display text-ink-900 mb-2">Billing</h1>
+      <p className="text-slate-600 mb-8">
+        Manage your StoryScribe subscription.
+      </p>
+
+      {checkoutResult === 'success' && (
+        <div className="mb-6 flex items-center gap-2 rounded-ss-lg border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-800">
+          <CheckCircle className="h-4 w-4 shrink-0" />
+          <span>Payment complete — thanks for subscribing!</span>
+        </div>
+      )}
+      {checkoutResult === 'cancelled' && (
+        <div className="mb-6 flex items-center gap-2 rounded-ss-lg border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          <XCircle className="h-4 w-4 shrink-0" />
+          <span>Checkout was cancelled. You haven&apos;t been charged.</span>
+        </div>
+      )}
+      {checkoutError && (
+        <div className="mb-6 flex items-center gap-2 rounded-ss-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+          <XCircle className="h-4 w-4 shrink-0" />
+          <span>{checkoutError}</span>
+        </div>
+      )}
+
+      <div className="rounded-ss-lg border border-slate-300 bg-white p-6 shadow-ss-card">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 rounded-ss-lg bg-ink-50 border border-ink-300 flex items-center justify-center">
+            <CreditCard className="h-5 w-5 text-ink-900" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Basic subscription</h2>
+            <p className="text-sm text-slate-500">$10 / month</p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="h-10 bg-slate-100 rounded animate-pulse" />
+        ) : data?.active && subscription ? (
+          <div className="text-sm text-slate-700 space-y-1">
+            <p>
+              Status: <span className="font-medium text-green-700">{subscription.status}</span>
+            </p>
+            {subscription.currentPeriodEnd && (
+              <p>
+                {subscription.cancelAtPeriodEnd ? 'Ends' : 'Renews'} on{' '}
+                {formatDate(subscription.currentPeriodEnd, 'long')}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div>
+            {subscription && (
+              <p className="text-sm text-slate-500 mb-3">
+                Your previous subscription is <span className="font-medium">{subscription.status}</span>.
+              </p>
+            )}
+            <Button
+              onClick={() => {
+                setCheckoutError(null);
+                checkoutMutation.mutate();
+              }}
+              disabled={checkoutMutation.isPending}
+            >
+              {checkoutMutation.isPending ? 'Redirecting…' : 'Subscribe'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function BillingPage() {
+  return (
+    <Suspense fallback={null}>
+      <BillingContent />
+    </Suspense>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
-import { Home, User, LogOut, Settings, Scroll, PenTool, Archive, BookOpen, HardDrive, ChevronDown } from 'lucide-react';
+import { Home, User, LogOut, Settings, Scroll, PenTool, Archive, BookOpen, HardDrive, ChevronDown, CreditCard } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import Button from '@/components/ui/Button';
 
@@ -128,6 +128,14 @@ export default function Navbar() {
                       >
                         <HardDrive className="h-4 w-4" />
                         <span>My Uploads</span>
+                      </Link>
+                      <Link
+                        href="/billing"
+                        className="w-full px-3.5 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2 transition-colors duration-150"
+                        onClick={() => setShowProfileDropdown(false)}
+                      >
+                        <CreditCard className="h-4 w-4" />
+                        <span>Billing</span>
                       </Link>
                       <Link
                         href="/settings"

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,30 @@
+import Stripe from 'stripe';
+
+/**
+ * Managed Payments (Stripe as merchant of record, automatic tax) is a preview
+ * feature: the product-create and checkout-session calls must send this
+ * version header per request. The client itself is deliberately not pinned to
+ * an API version — it uses the SDK's default.
+ */
+export const STRIPE_PREVIEW_API_VERSION = '2026-02-25.preview';
+
+let stripeClient: Stripe | null = null;
+
+export function isStripeConfigured(): boolean {
+  return Boolean(process.env.STRIPE_SECRET_KEY);
+}
+
+/**
+ * Lazy singleton Stripe client. Throws if STRIPE_SECRET_KEY is unset — call
+ * isStripeConfigured() first on paths that should degrade gracefully.
+ */
+export function getStripe(): Stripe {
+  if (!stripeClient) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) {
+      throw new Error('STRIPE_SECRET_KEY is not set');
+    }
+    stripeClient = new Stripe(key);
+  }
+  return stripeClient;
+}

--- a/src/services/CLAUDE.md
+++ b/src/services/CLAUDE.md
@@ -59,6 +59,15 @@ loop. See `docs/PIPELINE_DURABILITY.md` for design and failure-mode analysis.
 - **All time-sensitive queue writes must use raw SQL `NOW()`**, never Prisma's `@default(now())`/`new Date()` (app clock). The claim query compares `run_after <= NOW()` (DB clock); mixing clock sources made jobs unclaimable when a podman VM clock drifted 13 min. Symptom: jobs stuck `pending` with `run_after` "in the future" relative to `SELECT NOW()`.
 - The process route sets an **optimistic status** (`transcribing`/`summarizing`) on successful enqueue — so a session sitting in `uploaded` reliably means "no active job", which the UI uses to show a Start button.
 
+### `billing.ts` — Stripe Billing
+Subscription billing via Stripe Checkout with **Managed Payments** (preview: Stripe is merchant of record and handles tax). The Stripe client lives in `src/lib/stripe.ts`; product-create and checkout-session calls send the `2026-02-25.preview` version header per request (`STRIPE_PREVIEW_API_VERSION`).
+- `ensureSubscriptionPrice()` — resolves the $10/mo price: `STRIPE_PRICE_ID` env, else finds/creates the product tagged `app=dnd-session-recorder` (also creatable ahead of time via `scripts/stripe-setup.ts`)
+- `getOrCreateStripeCustomer(userId)` — persists `User.stripeCustomerId` on first use
+- `createSubscriptionCheckoutSession(userId, baseUrl)` — subscription-mode Checkout Session, `managed_payments[enabled]=true`, `client_reference_id`/`subscription_data.metadata.userId` carry the user id to webhooks
+- `handleStripeEvent(event)` / `syncSubscription(sub)` — webhook dispatch; upserts the `subscriptions` mirror row by `stripeSubscriptionId` (idempotent on replay). Stripe is the source of truth; the DB row is a cache for fast auth-time checks
+- `getUserSubscription(userId)` / `isSubscriptionActive(sub)` — status reads (`active`/`trialing` count as active)
+- Billing period is **item-level** (`subscription.items.data[0].current_period_end`) on current API versions, not on the subscription object
+
 ### `storage.ts` — Audio Storage Abstraction
 Two backends selected by env: Tigris/S3 object storage (`BUCKET_NAME` + `AWS_ENDPOINT_URL_S3`, set by `fly storage create`) or local `UPLOAD_DIR` (dev default). Every upload row carries a non-null `storageKey` (backend-relative); `localPathForKey` resolves it for the local backend.
 - `saveAudio(key, buffer, contentType)` / `deleteAudio(upload)` / `audioExists(upload)`

--- a/src/services/__tests__/billing.test.ts
+++ b/src/services/__tests__/billing.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Stripe from 'stripe';
+
+// The service touches Prisma and the Stripe client; mock both so these stay
+// pure-logic unit tests (dispatch routing, idempotent upsert keying, status).
+// Defined via vi.hoisted so the hoisted vi.mock factories can close over them.
+const { prismaMock, stripeMock } = vi.hoisted(() => ({
+  prismaMock: {
+    subscription: { upsert: vi.fn(), findFirst: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+  stripeMock: {
+    subscriptions: { retrieve: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/stripe', () => ({
+  getStripe: () => stripeMock,
+  STRIPE_PREVIEW_API_VERSION: '2026-02-25.preview',
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  handleStripeEvent,
+  syncSubscription,
+  isSubscriptionActive,
+} from '@/services/billing';
+
+function subscription(overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  return {
+    id: 'sub_1',
+    customer: 'cus_1',
+    status: 'active',
+    cancel_at_period_end: false,
+    metadata: { userId: 'user_1' },
+    items: { data: [{ price: { id: 'price_1' }, current_period_end: 1_700_000_000 }] },
+    ...overrides,
+  } as unknown as Stripe.Subscription;
+}
+
+describe('isSubscriptionActive', () => {
+  it('treats active and trialing as active, everything else as inactive', () => {
+    expect(isSubscriptionActive({ status: 'active' })).toBe(true);
+    expect(isSubscriptionActive({ status: 'trialing' })).toBe(true);
+    expect(isSubscriptionActive({ status: 'past_due' })).toBe(false);
+    expect(isSubscriptionActive({ status: 'canceled' })).toBe(false);
+    expect(isSubscriptionActive(null)).toBe(false);
+  });
+});
+
+describe('syncSubscription', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upserts keyed by stripeSubscriptionId (idempotent on replay)', async () => {
+    await syncSubscription(subscription());
+
+    expect(prismaMock.subscription.upsert).toHaveBeenCalledTimes(1);
+    const arg = prismaMock.subscription.upsert.mock.calls[0][0];
+    expect(arg.where).toEqual({ stripeSubscriptionId: 'sub_1' });
+    expect(arg.create.userId).toBe('user_1');
+    expect(arg.create.status).toBe('active');
+    // Billing period comes from the item, not the subscription object
+    expect(arg.create.currentPeriodEnd).toEqual(new Date(1_700_000_000 * 1000));
+    expect(arg.update.status).toBe('active');
+  });
+
+  it('falls back to the customer lookup when metadata has no userId', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce({ id: 'user_from_customer' });
+
+    await syncSubscription(subscription({ metadata: {} }));
+
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+      where: { stripeCustomerId: 'cus_1' },
+      select: { id: true },
+    });
+    expect(prismaMock.subscription.upsert.mock.calls[0][0].create.userId).toBe('user_from_customer');
+  });
+
+  it('skips the upsert when no user can be resolved', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    await syncSubscription(subscription({ metadata: {} }));
+
+    expect(prismaMock.subscription.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleStripeEvent', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('retrieves then syncs the subscription on checkout.session.completed', async () => {
+    stripeMock.subscriptions.retrieve.mockResolvedValueOnce(subscription());
+
+    await handleStripeEvent({
+      type: 'checkout.session.completed',
+      data: {
+        object: { mode: 'subscription', subscription: 'sub_1', client_reference_id: 'user_1' },
+      },
+    } as unknown as Stripe.Event);
+
+    expect(stripeMock.subscriptions.retrieve).toHaveBeenCalledWith('sub_1');
+    expect(prismaMock.subscription.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a non-subscription checkout session', async () => {
+    await handleStripeEvent({
+      type: 'checkout.session.completed',
+      data: { object: { mode: 'payment', subscription: null } },
+    } as unknown as Stripe.Event);
+
+    expect(stripeMock.subscriptions.retrieve).not.toHaveBeenCalled();
+    expect(prismaMock.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it('syncs directly on customer.subscription.updated/deleted', async () => {
+    await handleStripeEvent({
+      type: 'customer.subscription.deleted',
+      data: { object: subscription({ status: 'canceled' }) },
+    } as unknown as Stripe.Event);
+
+    expect(stripeMock.subscriptions.retrieve).not.toHaveBeenCalled();
+    expect(prismaMock.subscription.upsert.mock.calls[0][0].update.status).toBe('canceled');
+  });
+
+  it('ignores unhandled event types', async () => {
+    await handleStripeEvent({
+      type: 'invoice.payment_succeeded',
+      data: { object: {} },
+    } as unknown as Stripe.Event);
+
+    expect(prismaMock.subscription.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -1,0 +1,209 @@
+import Stripe from 'stripe';
+import type { Subscription } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getStripe, STRIPE_PREVIEW_API_VERSION } from '@/lib/stripe';
+import { logger } from '@/lib/logger';
+
+// The single subscription product this app sells. Identified in Stripe by
+// metadata so re-deploys and multiple environments don't create duplicates.
+const PRODUCT_METADATA_KEY = 'app';
+const PRODUCT_METADATA_VALUE = 'dnd-session-recorder';
+
+const SUBSCRIPTION_PRODUCT: Stripe.ProductCreateParams = {
+  name: 'Basic subscription',
+  description: 'A basic subscription to our service',
+  // Digital-product tax code required for Managed Payments eligibility
+  tax_code: 'txcd_10103100',
+  default_price_data: {
+    unit_amount: 1000,
+    currency: 'usd',
+    recurring: { interval: 'month' },
+  },
+  metadata: { [PRODUCT_METADATA_KEY]: PRODUCT_METADATA_VALUE },
+};
+
+let cachedPriceId: string | null = null;
+
+/**
+ * Resolve the monthly price to sell. Precedence: STRIPE_PRICE_ID env var,
+ * then an existing product tagged with our metadata, then create the product
+ * (with its default price) per the Managed Payments setup.
+ */
+export async function ensureSubscriptionPrice(): Promise<string> {
+  if (process.env.STRIPE_PRICE_ID) {
+    return process.env.STRIPE_PRICE_ID;
+  }
+  if (cachedPriceId) {
+    return cachedPriceId;
+  }
+
+  const stripe = getStripe();
+  const products = await stripe.products.list({ active: true, limit: 100 });
+  const existing = products.data.find(
+    (p) => p.metadata[PRODUCT_METADATA_KEY] === PRODUCT_METADATA_VALUE && p.default_price
+  );
+  if (existing) {
+    cachedPriceId =
+      typeof existing.default_price === 'string'
+        ? existing.default_price
+        : (existing.default_price as Stripe.Price).id;
+    return cachedPriceId;
+  }
+
+  const product = await stripe.products.create(SUBSCRIPTION_PRODUCT, {
+    apiVersion: STRIPE_PREVIEW_API_VERSION,
+  });
+  logger.info(`Created Stripe subscription product ${product.id}`);
+  cachedPriceId = product.default_price as string;
+  return cachedPriceId;
+}
+
+/**
+ * Return the user's Stripe customer id, creating the customer (and persisting
+ * the id on the User row) on first use.
+ */
+export async function getOrCreateStripeCustomer(userId: string): Promise<string> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { stripeCustomerId: true, email: true, name: true },
+  });
+  if (!user) {
+    throw new Error('User not found');
+  }
+  if (user.stripeCustomerId) {
+    return user.stripeCustomerId;
+  }
+
+  const customer = await getStripe().customers.create({
+    email: user.email ?? undefined,
+    name: user.name ?? undefined,
+    metadata: { userId },
+  });
+  await prisma.user.update({
+    where: { id: userId },
+    data: { stripeCustomerId: customer.id },
+  });
+  return customer.id;
+}
+
+/**
+ * Create a subscription-mode Checkout Session with Managed Payments enabled
+ * (Stripe acts as merchant of record and handles tax). Returns the session;
+ * redirect the browser to session.url.
+ */
+export async function createSubscriptionCheckoutSession(
+  userId: string,
+  baseUrl: string
+): Promise<Stripe.Checkout.Session> {
+  const [customerId, priceId] = await Promise.all([
+    getOrCreateStripeCustomer(userId),
+    ensureSubscriptionPrice(),
+  ]);
+
+  const params = {
+    mode: 'subscription',
+    customer: customerId,
+    client_reference_id: userId,
+    line_items: [{ price: priceId, quantity: 1 }],
+    subscription_data: { metadata: { userId } },
+    success_url: `${baseUrl}/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${baseUrl}/billing?checkout=cancelled`,
+    // Preview-only parameter, not yet in the SDK types (hence the cast)
+    managed_payments: { enabled: true },
+  } as Stripe.Checkout.SessionCreateParams;
+
+  return getStripe().checkout.sessions.create(params, {
+    apiVersion: STRIPE_PREVIEW_API_VERSION,
+  });
+}
+
+/**
+ * Upsert our mirror row from a Stripe subscription object. Stripe is the
+ * source of truth; upserting by stripeSubscriptionId keeps webhook replays
+ * and out-of-order deliveries idempotent.
+ */
+export async function syncSubscription(
+  subscription: Stripe.Subscription,
+  fallbackUserId?: string | null
+): Promise<void> {
+  const customerId =
+    typeof subscription.customer === 'string' ? subscription.customer : subscription.customer.id;
+
+  let userId = subscription.metadata?.userId || fallbackUserId || null;
+  if (!userId) {
+    const user = await prisma.user.findUnique({
+      where: { stripeCustomerId: customerId },
+      select: { id: true },
+    });
+    userId = user?.id ?? null;
+  }
+  if (!userId) {
+    logger.warn(`No user found for Stripe subscription ${subscription.id} (customer ${customerId})`);
+    return;
+  }
+
+  // Billing periods are item-level as of API 2025-03-31; single-item sub here
+  const item = subscription.items.data[0];
+  const currentPeriodEnd = item?.current_period_end
+    ? new Date(item.current_period_end * 1000)
+    : null;
+
+  await prisma.subscription.upsert({
+    where: { stripeSubscriptionId: subscription.id },
+    create: {
+      userId,
+      stripeSubscriptionId: subscription.id,
+      stripeCustomerId: customerId,
+      stripePriceId: item?.price?.id ?? null,
+      status: subscription.status,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    },
+    update: {
+      status: subscription.status,
+      stripePriceId: item?.price?.id ?? null,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    },
+  });
+  logger.info(`Synced Stripe subscription ${subscription.id} (${subscription.status})`, {
+    userId,
+  });
+}
+
+/**
+ * Dispatch a verified Stripe webhook event. Unhandled event types are ignored.
+ */
+export async function handleStripeEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (session.mode !== 'subscription' || !session.subscription) {
+        return;
+      }
+      const subscriptionId =
+        typeof session.subscription === 'string' ? session.subscription : session.subscription.id;
+      const subscription = await getStripe().subscriptions.retrieve(subscriptionId);
+      await syncSubscription(subscription, session.client_reference_id);
+      break;
+    }
+    case 'customer.subscription.updated':
+    case 'customer.subscription.deleted': {
+      await syncSubscription(event.data.object as Stripe.Subscription);
+      break;
+    }
+    default:
+      logger.debug(`Ignoring Stripe event ${event.type}`);
+  }
+}
+
+export async function getUserSubscription(userId: string): Promise<Subscription | null> {
+  return prisma.subscription.findFirst({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export function isSubscriptionActive(subscription: Pick<Subscription, 'status'> | null): boolean {
+  return subscription?.status === 'active' || subscription?.status === 'trialing';
+}

--- a/tests/ci/middleware/route-protection.spec.ts
+++ b/tests/ci/middleware/route-protection.spec.ts
@@ -22,7 +22,13 @@ test.describe('Route Protection', () => {
 
   test('unauthenticated access to /sessions/upload redirects to sign-in', async ({ page }) => {
     await page.goto('/sessions/upload');
-    
+
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+
+  test('unauthenticated access to /billing redirects to sign-in', async ({ page }) => {
+    await page.goto('/billing');
+
     await expect(page).toHaveURL(/\/auth\/signin/);
   });
 
@@ -40,12 +46,26 @@ test.describe('Route Protection', () => {
       '/api/sessions',
       '/api/campaigns',
       '/api/uploads',
+      '/api/billing/subscription',
     ];
 
     for (const route of protectedApiRoutes) {
       const response = await request.get(route);
       expect(response.status()).toBe(401);
     }
+
+    // checkout is POST-only — probe it with its real method (a GET would hit
+    // the route's 405 before auth matters)
+    const checkout = await request.post('/api/billing/checkout');
+    expect(checkout.status()).toBe(401);
+  });
+
+  test('Stripe webhook is public (authenticated by signature, not session)', async ({ request }) => {
+    // Middleware must let the webhook through — it carries no session cookie.
+    // A GET on this POST-only route returns 405 (or 503 when unconfigured),
+    // never 401, which proves middleware did not auth-block it.
+    const response = await request.get('/api/billing/webhook');
+    expect(response.status()).not.toBe(401);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds Stripe subscription billing ($10/mo) via Checkout with **Managed Payments** (Stripe as merchant of record, automatic tax). Stripe is the source of truth; a `Subscription` mirror table is kept current by webhook for fast auth-time checks.

- **Client** (`src/lib/stripe.ts`) — lazy singleton, `isStripeConfigured()` guard, preview API version header (`2026-02-25.preview`)
- **Service** (`src/services/billing.ts`) — price resolution (env → metadata-tagged product → create), customer create/persist, subscription Checkout Session, webhook dispatch + idempotent upsert keyed by `stripeSubscriptionId`
- **API routes** — `POST /api/billing/checkout` (sensitive-action rate limited), `GET /api/billing/subscription`, `POST /api/billing/webhook` (public — authenticated by signature, not session)
- **UI** — `/billing` page (status + Subscribe + success/cancel handling) and a Navbar link
- **Schema/migration** — `User.stripeCustomerId` + `subscriptions` table (guarded, `IF NOT EXISTS`)
- **Setup** — `scripts/stripe-setup.ts` to pin `STRIPE_PRICE_ID`; `.env.example` documented

Billing endpoints **503 when `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` are unset**, so this is inert until configured.

## Tests

- **Route protection** (`tests/ci/`) — `/billing` redirects unauthenticated; `/api/billing/checkout` (POST) + `/subscription` return 401; webhook stays public (not 401)
- **Webhook route** unit test — signature verification (missing/wrong/tampered → 400), valid dispatch → 200, handler failure → 500 (so Stripe retries)
- **Billing service** unit test — `handleStripeEvent` dispatch routing, `syncSubscription` idempotent-upsert keying + userId fallback, `isSubscriptionActive`

Verified locally: typecheck, lint, `npm run build`, full Vitest suite (103), route-protection (testcontainers, 8), and `prisma migrate diff --exit-code` (schema ↔ migration: no difference).

## Staging config required after merge

Staging deploys off `main`. For billing to function (not 503), set on the staging Fly app:
- `STRIPE_SECRET_KEY` — restricted `rk_` key (Customers, Products, Prices, Checkout Sessions, Subscriptions: write)
- `STRIPE_WEBHOOK_SECRET` — from a Dashboard webhook endpoint pointed at `https://<staging>/api/billing/webhook` (events: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`)
- Optionally `STRIPE_PRICE_ID` (from `scripts/stripe-setup.ts`) to pin the price per environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)